### PR TITLE
Sets isNetworkActivityIndicatorVisible on main thread

### DIFF
--- a/MyNewyorkTimes/Common/NetworkServices/NetworkService.swift
+++ b/MyNewyorkTimes/Common/NetworkServices/NetworkService.swift
@@ -237,7 +237,9 @@ public class NetworkService: NSObject, NetworkServiceInterface , ThreadSupport
         
         let task = sessionManager?.dataTask(with: urlReqeuest, completionHandler: { [weak self](resultData:Data?, response:URLResponse?, httpError:Error?) in
             
-            UIApplication.shared.isNetworkActivityIndicatorVisible = false
+            DispatchQueue.main.async {
+                UIApplication.shared.isNetworkActivityIndicatorVisible = false
+            }
             
             if let weakSelf = self
             {


### PR DESCRIPTION
allows tests to run on iOS 11 / XCode 9